### PR TITLE
Fix per-file generation with multi-file existing target

### DIFF
--- a/gazelle/python/generate.go
+++ b/gazelle/python/generate.go
@@ -223,40 +223,40 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			log.Printf("ERROR: %v\n", err)
 			return language.GenerateResult{}
 		}
-        }
+	}
 
-        existingMultiLibs := []struct{
-                name string
-                srcs *treeset.Set
-        }{}
-        if cfg.PerFileGeneration() && args.File != nil {
-                for _, r := range args.File.Rules {
-                        if r.Kind() != actualPyLibraryKind {
-                                continue
-                        }
-                        srcs := r.AttrStrings("srcs")
-                        pySrcs := make([]string, 0, len(srcs))
-                        for _, s := range srcs {
-                                if filepath.Ext(s) == ".py" {
-                                        pySrcs = append(pySrcs, s)
-                                }
-                        }
-                        if len(pySrcs) <= 1 {
-                                continue
-                        }
-                        set := treeset.NewWith(godsutils.StringComparator)
-                        for _, s := range pySrcs {
-                                set.Add(s)
-                                pyLibraryFilenames.Remove(s)
-                        }
-                        existingMultiLibs = append(existingMultiLibs, struct{
-                                name string
-                                srcs *treeset.Set
-                        }{r.Name(), set})
-                }
-        }
+	existingMultiLibs := []struct {
+		name string
+		srcs *treeset.Set
+	}{}
+	if cfg.PerFileGeneration() && args.File != nil {
+		for _, r := range args.File.Rules {
+			if r.Kind() != actualPyLibraryKind {
+				continue
+			}
+			srcs := r.AttrStrings("srcs")
+			pySrcs := make([]string, 0, len(srcs))
+			for _, s := range srcs {
+				if filepath.Ext(s) == ".py" {
+					pySrcs = append(pySrcs, s)
+				}
+			}
+			if len(pySrcs) <= 1 {
+				continue
+			}
+			set := treeset.NewWith(godsutils.StringComparator)
+			for _, s := range pySrcs {
+				set.Add(s)
+				pyLibraryFilenames.Remove(s)
+			}
+			existingMultiLibs = append(existingMultiLibs, struct {
+				name string
+				srcs *treeset.Set
+			}{r.Name(), set})
+		}
+	}
 
-        parser := newPython3Parser(args.Config.RepoRoot, args.Rel, cfg.IgnoresDependency)
+	parser := newPython3Parser(args.Config.RepoRoot, args.Rel, cfg.IgnoresDependency)
 	visibility := cfg.Visibility()
 
 	var result language.GenerateResult
@@ -346,25 +346,25 @@ func (py *Python) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			result.Imports = append(result.Imports, pyLibrary.PrivateAttr(config.GazelleImportsKey))
 		}
 	}
-        if cfg.PerFileGeneration() {
-                hasInit, nonEmptyInit := hasLibraryEntrypointFile(args.Dir)
-                pyLibraryFilenames.Each(func(index int, filename interface{}) {
-                        pyLibraryTargetName := strings.TrimSuffix(filepath.Base(filename.(string)), ".py")
-                        if filename == pyLibraryEntrypointFilename && !nonEmptyInit {
-                                return // ignore empty __init__.py.
-                        }
-                        srcs := treeset.NewWith(godsutils.StringComparator, filename)
-                        if cfg.PerFileGenerationIncludeInit() && hasInit && nonEmptyInit {
-                                srcs.Add(pyLibraryEntrypointFilename)
-                        }
-                        appendPyLibrary(srcs, pyLibraryTargetName)
-                })
-                for _, lib := range existingMultiLibs {
-                        appendPyLibrary(lib.srcs, lib.name)
-                }
-        } else {
-                appendPyLibrary(pyLibraryFilenames, cfg.RenderLibraryName(packageName))
-        }
+	if cfg.PerFileGeneration() {
+		hasInit, nonEmptyInit := hasLibraryEntrypointFile(args.Dir)
+		pyLibraryFilenames.Each(func(index int, filename interface{}) {
+			pyLibraryTargetName := strings.TrimSuffix(filepath.Base(filename.(string)), ".py")
+			if filename == pyLibraryEntrypointFilename && !nonEmptyInit {
+				return // ignore empty __init__.py.
+			}
+			srcs := treeset.NewWith(godsutils.StringComparator, filename)
+			if cfg.PerFileGenerationIncludeInit() && hasInit && nonEmptyInit {
+				srcs.Add(pyLibraryEntrypointFilename)
+			}
+			appendPyLibrary(srcs, pyLibraryTargetName)
+		})
+		for _, lib := range existingMultiLibs {
+			appendPyLibrary(lib.srcs, lib.name)
+		}
+	} else {
+		appendPyLibrary(pyLibraryFilenames, cfg.RenderLibraryName(packageName))
+	}
 
 	if hasPyBinaryEntryPointFile {
 		deps, _, annotations, err := parser.parseSingle(pyBinaryEntrypointFilename)

--- a/gazelle/python/testdata/per_file_respect_existing_multiple_srcs/BUILD.out
+++ b/gazelle/python/testdata/per_file_respect_existing_multiple_srcs/BUILD.out
@@ -5,10 +5,13 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 # This target should be maintained by gazelle (but should get a new deps).
 py_library(
     name = "custom",
-    srcs = ["bar.py", "baz.py"],
+    srcs = [
+        "bar.py",
+        "baz.py",
+    ],
+    tags = ["cant_touch_this"],
     visibility = ["//visibility:private"],
     deps = [":foo"],
-	tags = ["cant_touch_this"],
 )
 
 py_library(


### PR DESCRIPTION
## Summary
- handle existing py_library rules that contain multiple python files
- update per-file respect existing test golden

## Testing
- `bazel test -c dbg --test_output=errors //python:python_test_per_file_respect_existing_multiple_srcs`
- `bazel test -c dbg --test_output=errors //...`

------
https://chatgpt.com/codex/tasks/task_b_685dbf557c3c832ca01ccb2e006381fb